### PR TITLE
[Refactoring] Renamed deptree command to dependencies

### DIFF
--- a/cli/src/commands/dependencies.rs
+++ b/cli/src/commands/dependencies.rs
@@ -4,48 +4,48 @@ use clap::{Parser, Subcommand};
 use source_wand_dependency_analysis::{dependency_tree_request::DependencyTreeRequest, find_dependency_tree};
 
 #[derive(Debug, Parser)]
-pub struct DeptreeArgs {
+pub struct DependenciesArgs {
     #[command(subcommand)]
-    command: DeptreeCommand
+    command: DependenciesCommand
 }
 
 #[derive(Debug, Subcommand)]
-pub enum DeptreeCommand {
+pub enum DependenciesCommand {
     #[command(about = "From a local project.")]
-    Local(LocalDeptreeArgs),
+    Local(LocalDependenciesArgs),
     #[command(about = "From a project in a git repository.")]
-    Git(GitDeptreeArgs),
+    Git(GitDependenciesArgs),
     #[command(about = "From the name/version pair of a project.")]
-    ByName(NameDeptreeArgs),
+    ByName(NameDependenciesArgs),
 }
 
 #[derive(Debug, Parser)]
-pub struct LocalDeptreeArgs {
+pub struct LocalDependenciesArgs {
     path: PathBuf,
 }
 
 #[derive(Debug, Parser)]
-pub struct GitDeptreeArgs {
+pub struct GitDependenciesArgs {
     url: String,
     branch: Option<String>,
 }
 
 #[derive(Debug, Parser)]
-pub struct NameDeptreeArgs {
+pub struct NameDependenciesArgs {
     name: String,
     version: String,
 }
 
-pub fn deptree_command(args: &DeptreeArgs) -> Result<(), String> {
+pub fn dependencies_command(args: &DependenciesArgs) -> Result<(), String> {
     let dependency_tree = match &args.command {
-        DeptreeCommand::Local(args) => {
+        DependenciesCommand::Local(args) => {
             find_dependency_tree(
                 DependencyTreeRequest::LocalProject {
                     path: args.path.clone()
                 }
             )?
         },
-        DeptreeCommand::Git(args) => {
+        DependenciesCommand::Git(args) => {
             find_dependency_tree(
                 DependencyTreeRequest::GitProject {
                     url: args.url.clone(),
@@ -53,7 +53,7 @@ pub fn deptree_command(args: &DeptreeArgs) -> Result<(), String> {
                 }
             )?
         },
-        DeptreeCommand::ByName(args) => {
+        DependenciesCommand::ByName(args) => {
             find_dependency_tree(
                 DependencyTreeRequest::NameBased {
                     name: args.name.clone(),

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,1 +1,1 @@
-pub mod deptree;
+pub mod dependencies;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use commands::deptree::{deptree_command, DeptreeArgs};
+use commands::dependencies::{dependencies_command, DependenciesArgs};
 
 mod commands;
 
@@ -12,13 +12,13 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     #[command(about = "Find the dependency tree of a project.")]
-    Deptree(DeptreeArgs),
+    Dependencies(DependenciesArgs),
 }
 
 fn execute_command() -> Result<(), String> {
     match Cli::parse().command {
-        Command::Deptree(args) => {
-            deptree_command(&args)
+        Command::Dependencies(args) => {
+            dependencies_command(&args)
         }
     }
 }


### PR DESCRIPTION
The dependency tree generation command used to be called `deptree`. Now it is called `dependencies`. This change aims to improve readability and to provide a better CLI UX.