### PR TITLE
[Feature] Added --format argument to dependencies command with tree, json and yaml as possible values

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
+serde_json = "1.0.138"
+serde_yaml = "0.9.34"
 
 [dependencies.source-wand-common]
 path = "../common"

--- a/dependency-analysis/Cargo.toml
+++ b/dependency-analysis/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 lxd = "0.1.9"
 ptree = "0.5.2"
+serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0.138"
+serde_yaml = "0.9.34"
 uuid = { version = "1.13.1", features = ["v4"] }
 
 [dependencies.source-wand-common]

--- a/dependency-analysis/src/dependency_tree_node.rs
+++ b/dependency-analysis/src/dependency_tree_node.rs
@@ -1,7 +1,8 @@
 use ptree::{write_tree, TreeBuilder};
+use serde::{Deserialize, Serialize};
 use source_wand_common::project::Project;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DependencyTreeNode {
     pub project: Project,
     pub dependencies: Vec<Box<DependencyTreeNode>>,


### PR DESCRIPTION
You can now use the `--json` optional argument with the `source-wand dependencies` command to change the output format.

The possible values for `--json` are:
1. `tree`
2. `json`
3. `yaml`

By default (if no `--json` argument is provided), the value is `tree`.