### PR TITLE
[Feature] Added --flatten flag to dependencies command

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.27", features = ["derive"] }
+serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
 serde_yaml = "0.9.34"
 

--- a/dependency-analysis/src/lib.rs
+++ b/dependency-analysis/src/lib.rs
@@ -15,8 +15,12 @@ use source_wand_common::{dependency_ensurer::required_dependency::AnyRequiredDep
 use uuid::Uuid;
 
 pub mod dependency_tree_node;
+pub mod unique_dependencies_list;
+
 pub mod dependency_tree_request;
+
 pub mod build_systems;
+
 pub mod dependency_tree_generators;
 
 pub fn find_dependency_tree(request: DependencyTreeRequest) -> Result<DependencyTreeNode, String> {

--- a/dependency-analysis/src/unique_dependencies_list.rs
+++ b/dependency-analysis/src/unique_dependencies_list.rs
@@ -1,0 +1,61 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+use source_wand_common::project::Project;
+
+use crate::dependency_tree_node::DependencyTreeNode;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UniqueDependenciesList {
+    pub dependencies: Vec<Project>,
+}
+
+impl UniqueDependenciesList {
+    pub fn new(dependencies: Vec<Project>) -> Self {
+        UniqueDependenciesList { dependencies }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut representation: String = "".to_string();
+
+        for dependency in &self.dependencies {
+            representation += format!("Project: {}\n", dependency.name).as_str();
+            representation += format!("Version: {}\n", dependency.version).as_str();
+            representation += format!("License: {}\n", dependency.license).as_str();
+            representation += format!("Repository: {}\n", dependency.repository).as_str();
+            representation += format!("\n").as_str();
+        }
+
+        representation
+    }
+}
+
+impl DependencyTreeNode {
+    pub fn flatten(&self) -> UniqueDependenciesList {
+        let mut projects: Vec<Project> = Vec::new();
+        let mut visited: HashSet<String> = HashSet::new();
+
+        self.flatten_node(&mut projects, &mut visited);
+
+        projects.sort_by(
+            |a, b|
+            format!("{}{}", a.name, a.version).cmp(
+                &format!("{}{}", b.name, b.version)
+            )
+        );
+
+        UniqueDependenciesList::new(projects)
+    }
+
+    fn flatten_node(&self, projects: &mut Vec<Project>, visited: &mut HashSet<String>) {
+        let project_hash: String = format!("{}-{}", self.project.name, self.project.version);
+
+        if visited.insert(project_hash) {
+            projects.push(self.project.clone());
+        }
+
+        for dependency in &self.dependencies {
+            dependency.flatten_node(projects, visited);
+        }
+    }
+}


### PR DESCRIPTION
Added `--flatten` flag to `source-wand dependencies` command.

If `--flatten` flag is present, then the output is not a tree, but a list. Every project in the list is unique and the projects are sorted alphabetically by `{name}{version}`.

The `--format` argument works for lists as well as trees.