### PR TITLE
Resolve Go versions that are commits

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -73,14 +73,6 @@ pub fn init_command(args: &InitArgs) -> Result<()> {
         }
     };
 
-    /*
-    let dependency_tree: DependencyTreeNode = find_dependency_tree(
-        DependencyTreeRequest::GitProject {
-            url: args.from_git.clone(),
-            branch: args.checkout.clone(),
-        }
-    ).map_err(|e| Error::msg(e))?;
-    */
     let nb_dependencies: usize = dependency_tree.flatten().dependencies.len();
     println!(" > {} unique dependencies were found in the project", nb_dependencies);
     println!(" > Saving dependency tree");

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::{Error, Result};
 use clap::Parser;
 use source_wand_common::utils::write_yaml_file::write_yaml_file;
@@ -10,24 +12,76 @@ use source_wand_onboarding::plan::plan_onboarding::plan_onboarding;
 
 #[derive(Debug, Parser)]
 pub struct InitArgs {
-    #[arg(long)]
-    from_git: String,
-
-    #[arg(long)]
-    checkout: Option<String>,
+    #[command(subcommand)]
+    command: InitCommand,
 }
+
+#[derive(Debug, Parser)]
+pub enum InitCommand {
+    #[command(about = "From a local project.")]
+    Local(LocalDependenciesArgs),
+    #[command(about = "From a project in a git repository.")]
+    Git(GitDependenciesArgs),
+    #[command(about = "From the name/version pair of a project.")]
+    ByName(NameDependenciesArgs),
+}
+
+#[derive(Debug, Parser)]
+pub struct LocalDependenciesArgs {
+    path: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+pub struct GitDependenciesArgs {
+    url: String,
+    branch: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct NameDependenciesArgs {
+    name: String,
+    version: String,
+}
+
 
 pub fn init_command(args: &InitArgs) -> Result<()> {
     println!("Planning project onboarding");
     println!(" > Generating dependency tree");
 
+    let dependency_tree = match &args.command {
+        InitCommand::Local(args) => {
+            find_dependency_tree(
+                DependencyTreeRequest::LocalProject {
+                    path: args.path.clone()
+                }
+            ).map_err(|e| Error::msg(e))?
+        }
+        InitCommand::Git(args) => {
+            find_dependency_tree(
+                DependencyTreeRequest::GitProject {
+                    url: args.url.clone(),
+                    branch: args.branch.clone(),
+                }
+            ).map_err(|e| Error::msg(e))?
+        }
+        InitCommand::ByName(args) => {
+            find_dependency_tree(
+                DependencyTreeRequest::NameBased {
+                    name: args.name.clone(),
+                    version: args.version.clone(),
+                }
+            ).map_err(|e|Error::msg(e))?
+        }
+    };
+
+    /*
     let dependency_tree: DependencyTreeNode = find_dependency_tree(
         DependencyTreeRequest::GitProject {
             url: args.from_git.clone(),
             branch: args.checkout.clone(),
         }
     ).map_err(|e| Error::msg(e))?;
-
+    */
     let nb_dependencies: usize = dependency_tree.flatten().dependencies.len();
     println!(" > {} unique dependencies were found in the project", nb_dependencies);
     println!(" > Saving dependency tree");

--- a/dependency-analysis/src/dependency_tree_generators/go_dependency_tree_generator.rs
+++ b/dependency-analysis/src/dependency_tree_generators/go_dependency_tree_generator.rs
@@ -85,7 +85,16 @@ fn build_tree(
 
 fn parse_module(s: &str) -> (String, String) {
     if let Some((name, version)) = s.rsplit_once('@') {
-        (name.to_string(), version.to_string())
+        if let Some((_, version_2)) = s.split_once('-') {
+            if let Some((_, commit_hash)) = version_2.split_once('-') {
+                (name.to_string(), commit_hash[..6].to_string())
+            } else { // There's no timestamp/hash commit combo
+                (name.to_string(), version.to_string())
+            }
+        } else { // Standard Version (no extra "-")
+            (name.to_string(), version.to_string())
+        }
+        // (name.to_string(), version.to_string())
     } else {
         (s.to_string(), "".to_string())
     }

--- a/onboarding/src/plan/fetch_source.rs
+++ b/onboarding/src/plan/fetch_source.rs
@@ -43,7 +43,8 @@ pub fn fetch_source(project: &Project) -> Result<OnboardingSource> {
             branch.to_string()
         }
         else {
-            bail!("No tag or branch matches the package version")
+            project.version.to_string() 
+            //bail!("No tag or branch matches the package version")
         };
 
     Ok(OnboardingSource::git(project.repository.clone(), checkout))


### PR DESCRIPTION
# Problem
- There are many go modules where the version is "v0.0.0-<timestamp>-<commit>"
- Our program doesn't know how to resolve them

# Solution


# What's part of this PR?
- (Adding "local" to `init`) >> This is extra
- `fetch_source.rs` >> Doesn't ever throw "error" about no "branch" or "tag" >> just resolves to the version (which should be a commit)

# Additions
- Need to keep the "error" in fetch_source.rs
- Handle when it's "v1.2.3-b2" b/c I'm using "-" as a delimiter and throwing out the ones I don't need >> in this case, it will break