### PR TITLE
Validate that there is a commit which matches the commit hash in the dependency version

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -4,7 +4,6 @@ use anyhow::{Error, Result};
 use clap::Parser;
 use source_wand_common::utils::write_yaml_file::write_yaml_file;
 use source_wand_dependency_analysis::{
-    dependency_tree_node::DependencyTreeNode,
     dependency_tree_request::DependencyTreeRequest,
     find_dependency_tree
 };

--- a/cli/src/commands/onboard.rs
+++ b/cli/src/commands/onboard.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-pub struct OnboardArgs {
-    #[arg(long)]
-    from_git: String,
-}
+pub struct OnboardArgs;
 
 pub fn onboard_command(_args: &OnboardArgs) -> Result<()> {
     Ok(())

--- a/dependency-analysis/src/dependency_tree_generators/go_dependency_tree_generator.rs
+++ b/dependency-analysis/src/dependency_tree_generators/go_dependency_tree_generator.rs
@@ -85,16 +85,7 @@ fn build_tree(
 
 fn parse_module(s: &str) -> (String, String) {
     if let Some((name, version)) = s.rsplit_once('@') {
-        if let Some((_, version_2)) = s.split_once('-') {
-            if let Some((_, commit_hash)) = version_2.split_once('-') {
-                (name.to_string(), commit_hash[..6].to_string())
-            } else { // There's no timestamp/hash commit combo
-                (name.to_string(), version.to_string())
-            }
-        } else { // Standard Version (no extra "-")
-            (name.to_string(), version.to_string())
-        }
-        // (name.to_string(), version.to_string())
+        (name.to_string(), version.to_string())
     } else {
         (s.to_string(), "".to_string())
     }

--- a/onboarding/Cargo.toml
+++ b/onboarding/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.45.1", features = ["full"] }
 futures = "0.3.31"
 colorize = "0.1.0"
+regex = "1.11.1"


### PR DESCRIPTION
This is an amendment proposal for [this PR](https://github.com/canonical/source-wand/pull/19).

Instead of parsing the commit hash in the dependency tree generator and then assuming the commit exists, `source-wand` now tries to checkout the commit hash for versions that contain a commit hash. This way we only mark the dependencies as valid if the commit hash exists in the repository (it turns out that this is not always the case).