### PR TITLE
Retry Get calls (429 error)

### DIFF
--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -73,14 +73,6 @@ pub fn init_command(args: &InitArgs) -> Result<()> {
         }
     };
 
-    /*
-    let dependency_tree: DependencyTreeNode = find_dependency_tree(
-        DependencyTreeRequest::GitProject {
-            url: args.from_git.clone(),
-            branch: args.checkout.clone(),
-        }
-    ).map_err(|e| Error::msg(e))?;
-    */
     let nb_dependencies: usize = dependency_tree.flatten().dependencies.len();
     println!(" > {} unique dependencies were found in the project", nb_dependencies);
     println!(" > Saving dependency tree");


### PR DESCRIPTION
There was an issue where we made too many requests to pkg.go.dev so it would give us 429 errors.
This PR is meant to allow them to retry up to 3 times (1s -> 2s).